### PR TITLE
Potential fix for code scanning alert no. 10: Unsigned difference expression compared to zero

### DIFF
--- a/mtcp/src/tcp_out.c
+++ b/mtcp/src/tcp_out.c
@@ -542,7 +542,7 @@ FlushTCPSendingBuffer(mtcp_manager_t mtcp, tcp_stream *cur_stream, uint32_t cur_
 			               - (seq - sndvar->snd_una);
 		/* if there is no space in the window */
 		if (remaining_window <= 0 ||
-		    (remaining_window < sndvar->mss && seq - sndvar->snd_una > 0)) {
+		    (remaining_window < sndvar->mss && TCP_SEQ_GT(seq, sndvar->snd_una))) {
 			/* if peer window is full, send ACK and let its peer advertises new one */
 			if (sndvar->peer_wnd <= sndvar->cwnd) {
 #if 0


### PR DESCRIPTION
Potential fix for [https://github.com/Harvester57/mtcp/security/code-scanning/10](https://github.com/Harvester57/mtcp/security/code-scanning/10)

The problematic code is:
```c
if (remaining_window <= 0 ||
    (remaining_window < sndvar->mss && seq - sndvar->snd_una > 0))
```
The expression `seq - sndvar->snd_una > 0` should be replaced with a proper TCP sequence number comparison macro, typically `TCP_SEQ_GT(seq, sndvar->snd_una)`, which correctly handles wraparound for unsigned TCP sequence values.

**How to fix:**  
- Replace `seq - sndvar->snd_una > 0` with `TCP_SEQ_GT(seq, sndvar->snd_una)`.
- No new imports or library dependencies are required, as the macro is already used elsewhere in the file.
- Only the logic inside the `if` at line 545 needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
