### PR TITLE
Potential fix for code scanning alert no. 35: Use of potentially dangerous function

### DIFF
--- a/apps/lighttpd-1.4.32/src/response.c
+++ b/apps/lighttpd-1.4.32/src/response.c
@@ -101,8 +101,9 @@ int http_response_write_header(server *srv, connection *con) {
 		if (srv->cur_ts != srv->last_generated_date_ts) {
 			buffer_prepare_copy(srv->ts_date_str, 255);
 
+			struct tm tm;
 			strftime(srv->ts_date_str->ptr, srv->ts_date_str->size - 1,
-				 "%a, %d %b %Y %H:%M:%S GMT", gmtime(&(srv->cur_ts)));
+				 "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&(srv->cur_ts), &tm));
 
 			srv->ts_date_str->used = strlen(srv->ts_date_str->ptr) + 1;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Harvester57/mtcp/security/code-scanning/35](https://github.com/Harvester57/mtcp/security/code-scanning/35)

To fix this problem, we should replace the unsafe `gmtime` call with the thread-safe variant `gmtime_r`. In the corrected logic, we allocate a `struct tm` on the stack, then call `gmtime_r`, passing both the source time value and a pointer to the result struct. We then pass a pointer to the result struct to `strftime`.

**Steps to fix:**
- In the block at line 105, declare a `struct tm` (e.g., `tm`).
- Replace `gmtime(&(srv->cur_ts))` with `gmtime_r(&(srv->cur_ts), &tm)`.
- Pass `&tm` to `strftime`.

All changes will be made around line 105 in `apps/lighttpd-1.4.32/src/response.c`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
